### PR TITLE
feat: make grepFilterSpecs work with negative grep

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -81,13 +81,13 @@ function cypressGrepPlugin(config) {
         const text = fs.readFileSync(specFile, { encoding: 'utf8' })
 
         try {
-          const names = getTestNames(text, false)
-          const testAndSuiteNames = names.suiteNames.concat(names.testNames)
+          const result = getTestNames(text, true)
+          const testNames = result.fullTestNames
 
           debug('spec file %s', specFile)
-          debug('suite and test names: %o', testAndSuiteNames)
+          debug('full test names: %o', testNames)
 
-          return testAndSuiteNames.some((name) => {
+          return testNames.some((name) => {
             const shouldRun = shouldTestRun(parsedGrep, name)
 
             return shouldRun


### PR DESCRIPTION
Hi @bahmutov what do you think about this change? It enables to pre-filter the specs when you use negative title grep.

And can you tell me how I should test it? e2e or unit? The test structure has changed somewhat since cypress-grep