### PR TITLE
Fix: cy-grep: could not find the tag "<tag>" in any of the specs

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -155,17 +155,20 @@ function cypressGrepPlugin(config) {
           // and the values being arrays of effective test tags
           debug('spec file %s', specFile)
           debug('effective test tags %o', testTags)
+
+          // remember all found tags
+          Object.entries(testTags).forEach(([testTitle, tags]) => {
+            tags.effectiveTags.forEach((tag) => {
+              foundTags.add(tag)
+            })
+            tags.requiredTags.forEach((tag) => {
+              foundTags.add(tag)
+            })
+          });
+
           return Object.keys(testTags).some((testTitle) => {
             const effectiveTags = testTags[testTitle].effectiveTags
             const requiredTags = testTags[testTitle].requiredTags
-
-            // remember all found tags
-            effectiveTags.forEach((tag) => {
-              foundTags.add(tag)
-            })
-            requiredTags.forEach((tag) => {
-              foundTags.add(tag)
-            })
 
             return shouldTestRun(
               parsedGrep,


### PR DESCRIPTION
when running cypress the message 'cy-grep: could not find the tag "<tag>" in any of the specs' may be presented as bug because the tag is indeed found in test specs, this bug happens because of Object.keys(testTags).some not looping over all testTags (early exit behavior).