### PR TITLE
feat: Adding new environment variable to obtain tags from all tests in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,44 @@ describe('parent', { tags: ['@p1', '@p2'] }, () => {
 })
 ```
 
+Additionally, you can check both tags and required tags for each test within the current spec by checking the `Cypress.env('specTags')` object
+
+See [spec.js](./cypress/e2e/spec.js) for practical test spec example.
+
+Example output:
+
+```js
+{
+    "hello world": {
+        "effectiveTestTags": [],
+        "requiredTestTags": []
+    },
+    "works": {
+        "effectiveTestTags": [],
+        "requiredTestTags": []
+    },
+    "works 2 @tag1": {
+        "effectiveTestTags": [
+            "@tag1"
+        ],
+        "requiredTestTags": []
+    },
+    "works 2 @tag1 @tag2": {
+        "effectiveTestTags": [
+            "@tag1",
+            "@tag2"
+        ],
+        "requiredTestTags": []
+    },
+    "works @tag2": {
+        "effectiveTestTags": [
+            "@tag2"
+        ],
+        "requiredTestTags": []
+    }
+}
+```
+
 ## Pre-filter specs (grepFilterSpecs)
 
 By default, when using `grep` and `grepTags` all specs are executed, and inside each the filters are applied. This can be very wasteful, if only a few specs contain the `grep` in the test titles. Thus when doing the positive `grep`, you can pre-filter specs using the `grepFilterSpecs=true` parameter.

--- a/cypress/e2e/spec.js
+++ b/cypress/e2e/spec.js
@@ -13,7 +13,41 @@ it('works 2 @tag1 @tag2', { tags: ['@tag1', '@tag2'] }, () => {
   expect(Cypress.env('testTags'), 'test tags').to.deep.equal(['@tag1', '@tag2'])
 })
 
-it('works @tag2', { tags: '@tag2' }, () => {})
+it('works @tag2', { tags: '@tag2' }, () => {
+  const specTags = `{
+    "hello world": {
+        "effectiveTestTags": [],
+        "requiredTestTags": []
+    },
+    "works": {
+        "effectiveTestTags": [],
+        "requiredTestTags": []
+    },
+    "works 2 @tag1": {
+        "effectiveTestTags": [
+            "@tag1"
+        ],
+        "requiredTestTags": []
+    },
+    "works 2 @tag1 @tag2": {
+        "effectiveTestTags": [
+            "@tag1",
+            "@tag2"
+        ],
+        "requiredTestTags": []
+    },
+    "works @tag2": {
+        "effectiveTestTags": [
+            "@tag2"
+        ],
+        "requiredTestTags": []
+    }
+}`
+
+  expect(JSON.stringify(Cypress.env('specTags')), 'spec tags').to.deep.equal(
+    JSON.stringify(JSON.parse(specTags)),
+  )
+})
 
 // a failed test if needed
 // comment out when done

--- a/src/support.js
+++ b/src/support.js
@@ -20,6 +20,10 @@ const _describe = describe
 // includes both the test tags and the suite tags
 // and the required test tags
 const testTree = {}
+// keeps all collected test tags by the individual test title
+// includes both the test tags and the suite tags
+// used to expose within a Cypress environment variable
+const modifiedTestTree = {}
 
 beforeEach(() => {
   // set the test tags for the current test
@@ -136,6 +140,10 @@ function registerCyGrep() {
       .map((item) => item.name)
       .concat(name)
       .join(' ')
+    const nameOfTest = suiteStack
+      .map((item) => item.name)
+      .concat(name)
+      .pop()
     const effectiveTestTags = suiteStack
       .flatMap((item) => item.tags)
       .concat(configTags)
@@ -146,6 +154,11 @@ function registerCyGrep() {
       .filter(Boolean)
     debug({ nameToGrep, effectiveTestTags, requiredTestTags })
     testTree[nameToGrep] = { effectiveTestTags, requiredTestTags }
+
+    // Store the tags by individual name of test
+    // Expose the object within the Cypress environment variables
+    modifiedTestTree[nameOfTest] = { effectiveTestTags, requiredTestTags }
+    Cypress.env('specTags', modifiedTestTree)
 
     const shouldRun = shouldTestRun(
       parsedGrep,


### PR DESCRIPTION
Hey @bahmutov, I've been working on adding test tags to [cypress-plugin-grep-boxes](https://github.com/dennisbergevin/cypress-plugin-grep-boxes):

Prototype example: 

<img width="1185" height="626" alt="Screenshot 2025-10-20 at 2 39 00 PM" src="https://github.com/user-attachments/assets/693279c4-2227-46fa-a169-8dd9a2116e1e" />

It will allow user to both see tags associated with tests in the UI and allow them to click a tag to run only tests with that given tag, similar to Playwright `--ui` mode.

To support this effort, when a spec is opened in the Cypress `open` mode locally, we currently don't have a way to obtain all tests and tags at once so that we know tests and their respective tags.

This adds a new `Cypress.env('specTags')` which can be used upon initial spec load to populate the tags to each respective test runnable in the UI.

Additionally, a test and README update has been added.

I've chosen to use the individual test title, and not to expose the current `testTree` with full test title, for convenience of comparing the test title in the UI against the resulting object.